### PR TITLE
Add new modpacks sidebar

### DIFF
--- a/src/components/sidebar/ModpacksSidebar.vue
+++ b/src/components/sidebar/ModpacksSidebar.vue
@@ -1,0 +1,147 @@
+<template>
+	<div class="card flex-card experimental-styles-within">
+		<button
+			class="flex w-full items-center justify-between gap-2 text-left text-lg font-semibold m-0 text-primary"
+			@click="expanded = !expanded"
+			:disabled="loading || error || modpacks.length === 0"
+		>
+			<h2 class="m-0">{{ formatMessage(messages.title) }}</h2>
+			<ChevronRightIcon
+				v-if="totalHits > 4"
+				aria-hidden="true"
+				class="shrink-0 transition-transform"
+				:class="{ 'rotate-90': expanded }"
+			/>
+		</button>
+		<div v-if="loading" class="details-list min-w-0 max-w-full">
+			<div class="details-list__item !w-full min-w-0 max-w-full !items-start">
+				<LoaderCircleIcon class="mt-0.5 shrink-0 animate-spin" />
+				<span class="min-w-0 flex-1 break-words leading-tight"> Loading </span>
+			</div>
+		</div>
+		<div v-else-if="error" class="details-list min-w-0 max-w-full">
+			<div class="details-list__item !w-full min-w-0 max-w-full !items-start font-normal text-secondary">
+				<span class="min-w-0 flex-1 break-words leading-tight">
+					Failed to load modpacks
+				</span>
+			</div>
+		</div>
+		<div v-else-if="modpacks.length === 0" class="details-list min-w-0 max-w-full">
+			<div class="details-list__item !w-full min-w-0 max-w-full !items-start text-secondary">
+				<XIcon aria-hidden="true" class="mt-0.5 shrink-0" />
+				<span class="min-w-0 flex-1 break-words leading-tight">
+					No modpacks found
+				</span>
+			</div>
+		</div>
+		<div v-else class="details-list min-w-0 max-w-full">
+			<ScrollablePanel v-if="expanded" class="[&__.scrollable-pane]:max-h-96">
+				<ul class="m-0 flex list-none flex-col gap-3 p-0 pr-2">
+					<li v-for="modpack in modpacks" :key="modpack.project_id">
+						<a
+							:href="`https://modrinth.com/modpack/${modpack.slug}`"
+							target="_blank"
+							rel="noopener"
+							class="details-list__item !w-full min-w-0 max-w-full !items-center hover:underline"
+						>
+							<img
+								:src="modpack.icon_url"
+								:alt="modpack.title"
+								class="mt-0.5 h-8 w-8 shrink-0 rounded"
+							/>
+							<span class="min-w-0 flex-1 break-words leading-tight">
+								{{ modpack.title }}
+							</span>
+						</a>
+					</li>
+				</ul>
+			</ScrollablePanel>
+			<div v-else class="relative flex list-none flex-col gap-3 p-0 pr-2">
+				<a
+					v-for="modpack in visibleModpacks"
+					:key="modpack.project_id"
+					:href="`https://modrinth.com/modpack/${modpack.slug}`"
+					target="_blank"
+					rel="noopener"
+					class="details-list__item !w-full min-w-0 max-w-full !items-center hover:underline"
+				>
+					<img
+						:src="modpack.icon_url"
+						:alt="modpack.title"
+						class="mt-0.5 h-8 w-8 shrink-0 rounded"
+					/>
+					<span class="min-w-0 flex-1 break-words leading-tight">
+						{{ modpack.title }}
+					</span>
+				</a>
+				<div
+					v-if="totalHits > 4"
+					class="absolute inset-x-0 bottom-0 flex h-16 items-end justify-center pb-1"
+				>
+					<div class="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-surface-3 to-transparent" />
+					<button
+						type="button"
+						class="relative text-sm font-medium text-secondary hover:underline"
+						@click="expanded = true"
+					>
+						{{ formatMessage(messages.moreModpacks) }}
+					</button>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { ChevronRightIcon, XIcon } from '@lucide/vue'
+import { LoaderCircleIcon } from '@modrinth/assets'
+import { ScrollablePanel, defineMessages, useVIntl } from '@modrinth/ui'
+import { computed, onMounted, ref } from 'vue'
+
+import { modrinthClient } from '../../utils/api'
+
+const { formatMessage } = useVIntl()
+const messages = defineMessages({
+	title: { id: 'modpacksSidebar.title', defaultMessage: 'Modpacks' },
+	moreModpacks: {
+		id: 'modpacksSidebar.more',
+		defaultMessage: 'Show more modpacks',
+	},
+})
+
+const props = defineProps<{ pageUrl: string }>()
+
+const modpacks = ref<Array<{ project_id: string; slug: string; title: string; icon_url: string }>>(
+	[],
+)
+const totalHits = ref(0)
+const loading = ref(true)
+const error = ref(false)
+const expanded = ref(false)
+
+const visibleModpacks = computed(() => modpacks.value.slice(0, 4))
+
+onMounted(async () => {
+	try {
+		const slug = new URL(props.pageUrl).pathname.match(
+			/^\/(mod|plugin|datapack|shader|resourcepack|modpack|server)\/([^/]+)/,
+		)?.[2]
+		if (!slug) return
+
+		const project = await modrinthClient.labrinth.projects_v2.get(slug)
+		const result = await modrinthClient.labrinth.projects_v2.search({
+			new_filters: `compatible_dependency_project_ids = \`${project.id}\` AND project_types = \`modpack\``,
+			limit: 100,
+			index: 'downloads',
+		})
+
+		modpacks.value = result.hits
+		totalHits.value = result.total_hits
+	} catch (err) {
+		console.error('[Modrinth Extras] Failed to load modpacks:', err)
+		error.value = true
+	} finally {
+		loading.value = false
+	}
+})
+</script>

--- a/src/components/sidebar/ModpacksSidebar.vue
+++ b/src/components/sidebar/ModpacksSidebar.vue
@@ -2,8 +2,8 @@
 	<div class="card flex-card experimental-styles-within">
 		<button
 			class="flex w-full items-center justify-between gap-2 text-left text-lg font-semibold m-0 text-primary"
-			@click="expanded = !expanded"
 			:disabled="loading || error || modpacks.length === 0"
+			@click="expanded = !expanded"
 		>
 			<h2 class="m-0">{{ formatMessage(messages.title) }}</h2>
 			<ChevronRightIcon
@@ -20,18 +20,16 @@
 			</div>
 		</div>
 		<div v-else-if="error" class="details-list min-w-0 max-w-full">
-			<div class="details-list__item !w-full min-w-0 max-w-full !items-start font-normal text-secondary">
-				<span class="min-w-0 flex-1 break-words leading-tight">
-					Failed to load modpacks
-				</span>
+			<div
+				class="details-list__item !w-full min-w-0 max-w-full !items-start font-normal text-secondary"
+			>
+				<span class="min-w-0 flex-1 break-words leading-tight"> Failed to load modpacks </span>
 			</div>
 		</div>
 		<div v-else-if="modpacks.length === 0" class="details-list min-w-0 max-w-full">
 			<div class="details-list__item !w-full min-w-0 max-w-full !items-start text-secondary">
 				<XIcon aria-hidden="true" class="mt-0.5 shrink-0" />
-				<span class="min-w-0 flex-1 break-words leading-tight">
-					No modpacks found
-				</span>
+				<span class="min-w-0 flex-1 break-words leading-tight"> No modpacks found </span>
 			</div>
 		</div>
 		<div v-else class="details-list min-w-0 max-w-full">
@@ -78,7 +76,9 @@
 					v-if="totalHits > 4"
 					class="absolute inset-x-0 bottom-0 flex h-16 items-end justify-center pb-1"
 				>
-					<div class="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-surface-3 to-transparent" />
+					<div
+						class="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-surface-3 to-transparent"
+					/>
 					<button
 						type="button"
 						class="relative text-sm font-medium text-secondary hover:underline"
@@ -95,7 +95,7 @@
 <script setup lang="ts">
 import { ChevronRightIcon, XIcon } from '@lucide/vue'
 import { LoaderCircleIcon } from '@modrinth/assets'
-import { ScrollablePanel, defineMessages, useVIntl } from '@modrinth/ui'
+import { defineMessages, ScrollablePanel, useVIntl } from '@modrinth/ui'
 import { computed, onMounted, ref } from 'vue'
 
 import { modrinthClient } from '../../utils/api'

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -14,6 +14,7 @@ import TranslateDescription from '../components/project/TranslateDescription.vue
 import DependencySidebar from '../components/sidebar/dependencies/DependencySidebar.vue'
 import DiscordSidebar from '../components/sidebar/DiscordSidebar.vue'
 import GitHubSidebar from '../components/sidebar/GitHubSidebar.vue'
+import ModpacksSidebar from '../components/sidebar/ModpacksSidebar.vue'
 import ToolsSidebar from '../components/sidebar/ToolsSidebar.vue'
 import ErrorNotice from '../components/site/ErrorNotice.vue'
 import FooterBadge from '../components/site/FooterBadge.vue'
@@ -525,6 +526,21 @@ export default defineContentScript({
 			},
 		})
 
+		const modpacksSidebar = createInjection({
+			id: 'modrinth-extras-modpacks-sidebar',
+			isEnabled: () => settings.modpacksSidebar.enabled,
+			settingsKeys: ['modpacksSidebar'],
+			persistent: false,
+			projectScoped: true,
+			attach: attachToSidebar,
+			createApp() {
+				const pageUrl = window.location.href.split('?')[0].split('#')[0]
+				const app = createApp(h(ModpacksSidebar, { pageUrl }))
+				installI18n(app)
+				return app
+			},
+		})
+
 		const errorNotice = createInjection({
 			id: 'modrinth-extras-error-notice',
 			isEnabled: () => true,
@@ -618,6 +634,7 @@ export default defineContentScript({
 			notifications,
 			toolsSidebar,
 			dependencySidebar,
+			modpacksSidebar,
 			activitySparkline,
 			galleryBackground,
 			monetizationBadge,

--- a/src/entrypoints/popup/App.vue
+++ b/src/entrypoints/popup/App.vue
@@ -248,6 +248,7 @@ import {
 	LayoutTemplateIcon,
 	LoaderCircleIcon,
 	MonitorIcon,
+	PackageIcon,
 	PaletteIcon,
 	PlayIcon,
 	SearchIcon,
@@ -423,6 +424,14 @@ const messages = defineMessages({
 		id: 'feature.discordSidebar.description',
 		defaultMessage:
 			'Server name, description, member count, and online count for linked Discord servers.',
+	},
+	'feature.modpacksSidebar.title': {
+		id: 'feature.modpacksSidebar.title',
+		defaultMessage: 'Modpacks sidebar',
+	},
+	'feature.modpacksSidebar.description': {
+		id: 'feature.modpacksSidebar.description',
+		defaultMessage: 'Show all the modpacks the mod is featured in.',
 	},
 	'feature.galleryBackground.title': {
 		id: 'feature.galleryBackground.title',
@@ -694,6 +703,12 @@ const contentPageFeatures = computed<FeatureDef[]>(() => [
 		icon: DiscordIcon,
 		title: formatMessage(messages['feature.discordSidebar.title']),
 		description: formatMessage(messages['feature.discordSidebar.description']),
+	},
+	{
+		key: 'modpacksSidebar',
+		icon: PackageIcon,
+		title: formatMessage(messages['feature.modpacksSidebar.title']),
+		description: formatMessage(messages['feature.modpacksSidebar.description']),
 	},
 	{
 		key: 'galleryBackground',

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -40,6 +40,7 @@ export interface ExtensionSettings {
 	dependencyExplorer: { enabled: boolean }
 	githubSidebar: { enabled: boolean }
 	discordSidebar: { enabled: boolean }
+	modpacksSidebar: { enabled: boolean }
 	galleryBackground: { enabled: boolean }
 	monetizationBadge: { enabled: boolean }
 	translateDescription: { enabled: boolean }
@@ -67,6 +68,7 @@ export const DEFAULTS: ExtensionSettings = {
 	dependencyExplorer: { enabled: true },
 	githubSidebar: { enabled: true },
 	discordSidebar: { enabled: true },
+	modpacksSidebar: { enabled: true },
 	galleryBackground: { enabled: true },
 	monetizationBadge: { enabled: true },
 	translateDescription: { enabled: false },


### PR DESCRIPTION
# Modpacks sidebar

So as the (probably) first ever human pull request i present the modpacks sidebar!

# Why use it?

A. if you are a mod dev and just wanna see if your mod is featured anywhere

B. if you love a mod and want to find modpacks for it

# what is a modpacks sidebar?

With the Modpacks sidebar you can view all of the modpacks in which the mod you selected is featured in (for this example its [Sodium](https://modrinth.com/mod/sodium))

<img width="1623" height="627" alt="Sodium Modpack Test" src="https://github.com/user-attachments/assets/cf503de5-e491-480a-b0bf-0a48dfb0da7d" />

Its also extendable which means it wont use up tons of space!

## Retracted

<img width="390" height="327" alt="retracted" src="https://github.com/user-attachments/assets/f8076835-b630-4e78-a3a8-3bfb6d3379ee" /> 

## Extended

<img width="402" height="592" alt="extended" src="https://github.com/user-attachments/assets/e5b96796-be30-4259-b6d6-18e0e018817d" />

Yeah thats really all i gotta say i dont know what else really.

I hope this gets merged :D