### PR TITLE
Spanish isn't showing

### DIFF
--- a/src/utils/locales.ts
+++ b/src/utils/locales.ts
@@ -12,7 +12,7 @@ export const LOCALES: LocaleDefinition[] = [
 	// { code: 'de-CH', name: 'Schweizerdeutsch' },
 	{ code: 'de-DE', name: 'Deutsch' },
 	{ code: 'es-419', name: 'Español (Latinoamérica)' },
-	// { code: 'es-ES', name: 'Español' },
+	{ code: 'es-ES', name: 'Español' },
 	// { code: 'fi-FI', name: 'Suomi' },
 	// { code: 'fil-PH', name: 'Filipino' },
 	{ code: 'fr-FR', name: 'Français' },


### PR DESCRIPTION
Due to the addition of the Spanish language being complete (Not Spanish (Latinoamérica)) it isn't on the popup!

It just adds it, that's it